### PR TITLE
Update mongoose.connect for >4.11

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,9 @@ app.use(bodyParser.json());
 global.__appRoot = path.normalize(__dirname);
 
 mongoose.Promise = global.Promise;
-mongoose.connect(environment.connectionString);
+mongoose.connect(environment.connectionString, {
+  useMongoClient: true,
+});
 
 app.use(require('./routers'));
 


### PR DESCRIPTION
Removes deprecation warning:

> DeprecationWarning: `openSet()` is deprecated in mongoose >= 4.11.0, use `openUri()` instead, or set the `useMongoClient` option if using `connect()` or `createConnection()`. See http://mongoosejs.com/docs/connections.html#use-mongo-client

From the docs:

> Mongoose's default connection logic is deprecated as of 4.11.0. Please opt in to the new connection logic using the useMongoClient option, but make sure you test your connections first if you're upgrading an existing codebase!

